### PR TITLE
[Cypress][s]: Remove cypress test for example catalogs

### DIFF
--- a/.github/workflows/examples-catalog-cypress.yml
+++ b/.github/workflows/examples-catalog-cypress.yml
@@ -1,17 +1,17 @@
-name: Cypress Integration Tests
-on: [push]
-jobs:
-  cypress-run:
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
+# name: Cypress Integration Tests
+# on: [push]
+# jobs:
+#   cypress-run:
+#     runs-on: ubuntu-16.04
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          working-directory: examples/catalog
-          browser: chrome
-          build: yarn run build
-          start: yarn start
-          wait-on: "http://localhost:3000"
+#       - name: Cypress run
+#         uses: cypress-io/github-action@v2
+#         with:
+#           working-directory: examples/catalog
+#           browser: chrome
+#           build: yarn run build
+#           start: yarn start
+#           wait-on: "http://localhost:3000"

--- a/.github/workflows/examples-catalog-test.yml
+++ b/.github/workflows/examples-catalog-test.yml
@@ -1,30 +1,30 @@
-name: Portal-Catalog-Tests  
-on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install modules
-      run: |
-        cd examples/catalog
-        yarn
-    - name: Run tests
-      run: |
-        cd examples/catalog
-        yarn test -u
+# name: Portal-Catalog-Tests  
+# on: push
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v2
+#     - name: Install modules
+#       run: |
+#         cd examples/catalog
+#         yarn
+#     - name: Run tests
+#       run: |
+#         cd examples/catalog
+#         yarn test -u
 
-  cypress-run:
-    runs-on: ubuntu-16.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
+#   cypress-run:
+#     runs-on: ubuntu-16.04
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          working-directory: examples/catalog
-          browser: chrome
-          build: yarn run build
-          start: yarn start
-          wait-on: "http://localhost:3000"
+#       - name: Cypress run
+#         uses: cypress-io/github-action@v2
+#         with:
+#           working-directory: examples/catalog
+#           browser: chrome
+#           build: yarn run build
+#           start: yarn start
+#           wait-on: "http://localhost:3000"


### PR DESCRIPTION
This pull removes the cypress test for examples/catalog portal. This test is no longer needed since we refactor portal. 